### PR TITLE
Add missing unit tests for Office application services

### DIFF
--- a/src/Infrastructure/Repositories/OfficeRepository.cs
+++ b/src/Infrastructure/Repositories/OfficeRepository.cs
@@ -12,7 +12,9 @@ public sealed class OfficeRepository : BaseRepository<Office, Guid>, IOfficeRepo
     public Task<Office?> FindByNameAsync(string name, CancellationToken token = default) =>
         Context.Offices.AsNoTracking().SingleOrDefaultAsync(e => e.Name == name, token);
 
-    public async Task<List<ApplicationUser>>
-        GetActiveStaffMembersListAsync(Guid id, CancellationToken token = default) =>
-        (await GetAsync(id, token)).StaffMembers.Where(e => e.Active).ToList();
+    public async Task<List<ApplicationUser>> GetActiveStaffMembersListAsync(
+        Guid id, CancellationToken token = default) =>
+        (await GetAsync(id, token)).StaffMembers
+        .Where(e => e.Active)
+        .OrderBy(e => e.LastName).ThenBy(e => e.FirstName).ToList();
 }

--- a/src/LocalRepository/Repositories/LocalOfficeRepository.cs
+++ b/src/LocalRepository/Repositories/LocalOfficeRepository.cs
@@ -11,7 +11,9 @@ public sealed class LocalOfficeRepository : BaseRepository<Office, Guid>, IOffic
     public Task<Office?> FindByNameAsync(string name, CancellationToken token = default) =>
         Task.FromResult(Items.SingleOrDefault(e => e.Name == name));
 
-    public async Task<List<ApplicationUser>>
-        GetActiveStaffMembersListAsync(Guid id, CancellationToken token = default) =>
-        (await GetAsync(id, token)).StaffMembers.Where(e => e.Active).ToList();
+    public async Task<List<ApplicationUser>> GetActiveStaffMembersListAsync(
+        Guid id, CancellationToken token = default) =>
+        (await GetAsync(id, token)).StaffMembers
+        .Where(e => e.Active)
+        .OrderBy(e => e.LastName).ThenBy(e => e.FirstName).ToList();
 }

--- a/tests/AppServicesTests/Offices/GetActiveStaff.cs
+++ b/tests/AppServicesTests/Offices/GetActiveStaff.cs
@@ -1,6 +1,36 @@
-﻿namespace AppServicesTests.Offices;
+﻿using MyAppRoot.AppServices.Offices;
+using MyAppRoot.AppServices.UserServices;
+using MyAppRoot.Domain.Identity;
+using MyAppRoot.Domain.Offices;
+using MyAppRoot.TestData.Constants;
+
+namespace AppServicesTests.Offices;
 
 public class GetActiveStaff
 {
-    // TODO: Add unit tests 
+    [Test]
+    public async Task WhenOfficeExists_ReturnsViewDtoList()
+    {
+        var user = new ApplicationUser
+        {
+            FirstName = TestConstants.ValidName,
+            LastName = TestConstants.NewValidName,
+            Email = TestConstants.ValidEmail,
+        };
+
+        var itemList = new List<ApplicationUser> { user };
+        var repoMock = new Mock<IOfficeRepository>();
+        repoMock.Setup(l => l.GetActiveStaffMembersListAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(itemList);
+        var managerMock = new Mock<IOfficeManager>();
+        var userServiceMock = new Mock<IUserService>();
+
+        var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
+            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+
+        var result = await appService.GetActiveStaffAsync(Guid.Empty);
+
+        result.Should().ContainSingle(e =>
+            e.FirstName == user.FirstName && e.LastName == user.LastName && e.Email == user.Email);
+    }
 }

--- a/tests/AppServicesTests/Offices/GetList.cs
+++ b/tests/AppServicesTests/Offices/GetList.cs
@@ -1,6 +1,5 @@
 ﻿using MyAppRoot.AppServices.Offices;
 using MyAppRoot.AppServices.UserServices;
-using MyAppRoot.Domain.Identity;
 using MyAppRoot.Domain.Offices;
 using MyAppRoot.TestData.Constants;
 
@@ -19,13 +18,27 @@ public class GetList
             .ReturnsAsync(itemList);
         var managerMock = new Mock<IOfficeManager>();
         var userServiceMock = new Mock<IUserService>();
-        userServiceMock.Setup(l => l.GetCurrentUserAsync())
-            .ReturnsAsync((ApplicationUser?)null);
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
             AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetListAsync();
 
         result.Should().BeEquivalentTo(itemList);
+    }
+
+    [Test]
+    public async Task WhenNoItemsExist_ReturnsEmptyList()
+    {
+        var repoMock = new Mock<IOfficeRepository>();
+        repoMock.Setup(l => l.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Office>());
+        var managerMock = new Mock<IOfficeManager>();
+        var userServiceMock = new Mock<IUserService>();
+        var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
+            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+
+        var result = await appService.GetListAsync();
+
+        result.Should().BeEmpty();
     }
 }

--- a/tests/AppServicesTests/Offices/Update.cs
+++ b/tests/AppServicesTests/Offices/Update.cs
@@ -1,6 +1,0 @@
-﻿namespace AppServicesTests.Offices;
-
-public class Update
-{
-    // TODO: Add unit tests
-}


### PR DESCRIPTION
Additional unit tests were added for `OfficeAppService` for the `GetActiveStaff` and `GetList` methods. 

The `UpdateAsync` method doesn't need unit tests; all contained methods are already unit tested elsewhere and there is no return value.

closes #5