### PR TITLE
Reorganize project references and add visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,62 @@ There are two launch profiles:
 * **WebApp Dev Server** — This profile connects to a remote database server for data and requires an SOG account to log in. *To use this profile, you must add the "appsettings.Development.json" file from the "app-config" repo.*
 
     Most development should be done using the Local profile. The Dev Server profile is only needed when specifically troubleshooting issues with the database server or SOG account.
+
+Here's a visualization of how each launch profile (plus the `BuildLocalDb` setting) configures the application at runtime.
+
+```mermaid
+flowchart LR
+    subgraph SPL["'Local' launch profile"]
+        direction LR
+        D[Domain]
+        T["Test Data (in memory)"]
+        R[Local Repository]
+        A[App Services]
+        W([Web App])
+
+        W --> A
+        A --> D
+        A --> R
+        R --> T
+        T --> D
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph SPB["'Local' launch profile + 'BuildLocalDb' setting"]
+        direction LR
+        D[Domain]
+        T[Test Data]
+        R[Infrastructure]
+        A[App Services]
+        W([Web App])
+        B[(LocalDB)]
+
+        W --> A
+        A --> D
+        R --> B
+        A --> R
+        T -->|Seed| B
+        B -.-> D
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph SPD["'Dev Server' launch profile (or Production)"]
+        direction LR
+        D[Domain]
+        R[Infrastructure]
+        A[App Services]
+        W([Web App])
+        B[(DB Server)]
+        Z[[Azure AD]]
+
+        W --> A
+        A --> D
+        A --> R
+        R ==>|VPN| B -.-> D
+        W ==>|SOG| Z
+    end
+```

--- a/src/Infrastructure/Contexts/SeedDevData/DbSeedDataHelpers.cs
+++ b/src/Infrastructure/Contexts/SeedDevData/DbSeedDataHelpers.cs
@@ -1,8 +1,7 @@
-﻿using MyAppRoot.Infrastructure.Contexts;
-using MyAppRoot.TestData.Identity;
+﻿using MyAppRoot.TestData.Identity;
 using MyAppRoot.TestData.Offices;
 
-namespace MyAppRoot.TestData.SeedData;
+namespace MyAppRoot.Infrastructure.Contexts.SeedDevData;
 
 public static class DbSeedDataHelpers
 {

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\AppServices\AppServices.csproj" />
-        <ProjectReference Include="..\Domain\Domain.csproj" />
+        <ProjectReference Include="..\TestData\TestData.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LocalRepository/LocalRepository.csproj
+++ b/src/LocalRepository/LocalRepository.csproj
@@ -16,7 +16,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\AppServices\AppServices.csproj" />
-        <ProjectReference Include="..\Domain\Domain.csproj" />
         <ProjectReference Include="..\TestData\TestData.csproj" />
     </ItemGroup>
 

--- a/src/TestData/Properties/AssemblyInfo.cs
+++ b/src/TestData/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AppServicesTests")]
+[assembly: InternalsVisibleTo("Infrastructure")]
 [assembly: InternalsVisibleTo("IntegrationTests")]
 [assembly: InternalsVisibleTo("LocalRepository")]
 [assembly: InternalsVisibleTo("LocalRepositoryTests")]

--- a/src/TestData/TestData.csproj
+++ b/src/TestData/TestData.csproj
@@ -16,7 +16,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Domain\Domain.csproj" />
-        <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/WebApp/Platform/Services/MigratorHostedService.cs
+++ b/src/WebApp/Platform/Services/MigratorHostedService.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using MyAppRoot.Domain.Identity;
 using MyAppRoot.Infrastructure.Contexts;
-using MyAppRoot.TestData.SeedData;
+using MyAppRoot.Infrastructure.Contexts.SeedDevData;
 using MyAppRoot.WebApp.Platform.Local;
 using MyAppRoot.WebApp.Platform.Settings;
 

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -27,7 +27,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Domain\Domain.csproj" />
         <ProjectReference Include="..\LocalRepository\LocalRepository.csproj" />
         <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     </ItemGroup>

--- a/tests/IntegrationTests/RepositoryHelper.cs
+++ b/tests/IntegrationTests/RepositoryHelper.cs
@@ -2,8 +2,8 @@
 using Microsoft.EntityFrameworkCore;
 using MyAppRoot.Domain.Offices;
 using MyAppRoot.Infrastructure.Contexts;
+using MyAppRoot.Infrastructure.Contexts.SeedDevData;
 using MyAppRoot.Infrastructure.Repositories;
-using MyAppRoot.TestData.SeedData;
 using TestSupport.EfHelpers;
 
 namespace IntegrationTests;


### PR DESCRIPTION
The Test Data and Infrastructure projects flowed in the wrong direction because of where the Seed Data Helpers class was located.