### PR TITLE
Update GitHub workflow triggers and naming

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,32 +1,17 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL Scan
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["main"]
   schedule:
     - cron: "21 19 * * 6"
 
 jobs:
-  analyze:
+  codeql-analysis:
     # ↓ Change this to "false" to disable the workflow without any alert messages.
     if: ${{ true }}
     # ↑ Change to "true" (or delete) to enable the workflow.
 
-    name: Analyze
+    name: Analyze with CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,18 +1,15 @@
-name: .NET Test
+name: .NET Unit Tests
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
-  build:
+  dotnet-test:
     # ↓ Change this to "false" to disable the workflow without any alert messages.
     if: ${{ true }}
     # ↑ Change to "true" (or delete) to enable the workflow.
-
-#    if: github.event.pull_request.draft == false
+    
+    name: Run unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/lighthouse-analysis.yml
+++ b/.github/workflows/lighthouse-analysis.yml
@@ -1,13 +1,15 @@
-
 name: Lighthouse Check
+
 on: 
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
-  workflow_dispatch:
+
 jobs:
-  lighthouse-check:
+  lighthouse-analysis:
+    # ↓ Change this to "false" to disable the workflow without any alert messages.
+    if: ${{ true }}
+    # ↑ Change to "true" (or delete) to enable the workflow.
+
+    name: Analyze with Lighthouse
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/raygun-deployment.yml
+++ b/.github/workflows/raygun-deployment.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   raygun-deployment:
+    name: Send deployment info to Raygun
     runs-on: ubuntu-latest
     steps:
       - name: Get the version number

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -1,17 +1,18 @@
-name: Scan with SonarCloud
+name: SonarCloud Scan
+
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+
 jobs:
-  build:
+  sonarcloud-scan:
     # ↓ Change this to "false" to disable the workflow without any alert messages.
     if: ${{ true }}
-    # ↑ Change to "true" to enable the workflow.
+    # ↑ Change to "true" (or delete) to enable the workflow.
 
-    name: Build
+    name: Analyze with SonarCloud
     runs-on: windows-latest
     steps:
       - name: Set up JDK 11

--- a/tests/code-coverage-readme.md
+++ b/tests/code-coverage-readme.md
@@ -15,11 +15,7 @@ Then run the following commands from the root directory (the coverlet commands s
 
 ```
 dotnet build
-coverlet .\.artifacts\DomainTests\bin\Debug\net6.0\DomainTests.dll --target "dotnet" --targetargs "test tests/DomainTests --no-build" --exclude "[TestData]*"
-coverlet .\.artifacts\IntegrationTests\bin\Debug\net6.0\IntegrationTests.dll --target "dotnet" --targetargs "test tests/IntegrationTests --no-build" --exclude "[TestData]*" --exclude "[Infrastructure]MyAppRoot.Infrastructure.Migrations.*" --merge-with "coverage.json"
-coverlet .\.artifacts\LocalRepositoryTests\bin\Debug\net6.0\LocalRepositoryTests.dll --target "dotnet" --targetargs "test tests/LocalRepositoryTests --no-build" --exclude "[TestData]*" --merge-with "coverage.json"
-coverlet .\.artifacts\AppServicesTests\bin\Debug\net6.0\AppServicesTests.dll --target "dotnet" --targetargs "test tests/AppServicesTests --no-build" --exclude "[TestData]*" --merge-with "coverage.json"
-coverlet .\.artifacts\WebAppTests\bin\Debug\net6.0\WebAppTests.dll --target "dotnet" --targetargs "test tests/WebAppTests --no-build" --exclude "[TestData]*" --exclude "[Infrastructure]MyAppRoot.Infrastructure.Migrations.*" --merge-with "coverage.json" -f=opencover -o="coverage.xml"
+[coverlet commands from "sonarcloud-scan.yml" file]
 reportgenerator -reports:coverage.xml -targetdir:coveragereport
 ```
 


### PR DESCRIPTION
Now that we have several GitHub workflows set up, I've gone through and adjusted the triggers for each to try to be more consistent and avoid unnecessary scans. Please take a look and let me know if the strategy looks sound. 

For example, a lot of the actions were being run twice -- first when the pull request was created and again when the PR was merged. The analysis-type actions are mostly only useful on pull requests where they can provide immediate feedback before merging. Also, I removed the PR branch restrictions, so any PR will get the same feedback even if it's not for the main branch.

Here's how each action will get triggered after this change:

| Action      | Triggers                                      |
|-------------|-----------------------------------------------|
| CodeQL scan | Pull request, weekly schedule<sup>1</sup>     |
| Unit tests  | Pull request                                  |
| Lighthouse  | Pull request                                  |
| SonarCloud  | Pull request, push to main branch<sup>2</sup> |
| Raygun      | Tagged for deployment                         |

1. CodeQL scans on a schedule so that it can catch any vulnerabilities discovered since the last PR.
2. I'm not sure if SonarCloud scanning is needed for pushes, but this is how it works in all of their documentation.

I've also updated some of the text that gets displayed in GitHub on the actions tab.