### PR TITLE
Update Entity Framework config and documentation

### DIFF
--- a/src/EfRepository/DbContext/AppDbContext.cs
+++ b/src/EfRepository/DbContext/AppDbContext.cs
@@ -25,6 +25,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
     {
         base.OnModelCreating(builder);
 
+        // === Unique indexes ===
+        builder.Entity<ApplicationUser>().HasIndex(user => user.ObjectIdentifier).IsUnique();
+
         // === Auto-includes ===
         // Some properties should always be included.
         // See https://learn.microsoft.com/en-us/ef/core/querying/related-data/eager#model-configuration-for-auto-including-navigations

--- a/src/EfRepository/EF-README.md
+++ b/src/EfRepository/EF-README.md
@@ -1,11 +1,24 @@
-### Entity Framework database migrations
+# Entity Framework Database Migrations
 
-Instructions for adding a new Entity Framework database migration:
+Any time changes are made to the `DbContext` or the domain entities that would require a modification to the database,
+this process can be managed using Entity Framework Migrations.
+
+## Setup
+
+Install the EF command line tool globally. This only needs to be done once.
+
+`dotnet tool install --global dotnet-ef`
+
+## Create a migration
 
 1. Build the solution.
 
-2. Open a command prompt to the "./src/EfRepository/" folder.
+2. Open a command prompt to the `./src/EfRepository/` folder.
 
-3. Run the following command with an appropriate migration name:
+3. Run the following command with an appropriate migration name in place of `NAME_OF_MIGRATION`:
 
    `dotnet ef migrations add NAME_OF_MIGRATION --msbuildprojectextensionspath ..\..\.artifacts\EfRepository\obj\`
+
+The above command generates database migration files in the `./src/EfRepository/Migrations` folder. (These should be
+committed to the Git repository.) New migrations will be automatically applied to the database the first time the 
+updated application is run.

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -9,7 +9,6 @@ using MyApp.AppServices.RegisterServices;
 using MyApp.WebApp.Platform.AppConfiguration;
 using MyApp.WebApp.Platform.Logging;
 using MyApp.WebApp.Platform.Settings;
-using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/tests/LocalRepositoryTests/Identity/RoleStore.cs
+++ b/tests/LocalRepositoryTests/Identity/RoleStore.cs
@@ -1,4 +1,5 @@
 using MyApp.LocalRepository.Identity;
+using MyApp.TestData.Constants;
 using System.Diagnostics;
 
 namespace LocalRepositoryTests.Identity;
@@ -43,6 +44,13 @@ public class RoleStore
         var role = _store.Roles.First();
         var result = await _store.FindByIdAsync(role.Id, CancellationToken.None);
         result.Should().BeEquivalentTo(role);
+    }
+
+    [Test]
+    public async Task FindById_WithInvalidId_ReturnsNull()
+    {
+        var result = await _store.FindByIdAsync(TextData.NonExistentName, CancellationToken.None);
+        result.Should().BeNull();
     }
 
     [Test]


### PR DESCRIPTION
This is a minor update to the the EF migration documentation.

Also, the `DbContext` is updated to ensure the User `ObjectIdentifier` remains unique in the DB Users table. This should already be the case based on how the table is used in the application, but this adds an additional data integrity constraint.